### PR TITLE
Added Faucet to Shelley

### DIFF
--- a/resources/content/articles/en/2020-05-04_05-00-00_faucet-en.md
+++ b/resources/content/articles/en/2020-05-04_05-00-00_faucet-en.md
@@ -22,4 +22,4 @@ The faucet is a web-based service that provides test ada (also known as 'tADA', 
 
 _When you have finished using your test tokens, please return them to the faucet so that other members of the community can use them. Please return your test tokens to this address:_
 
-__615609ae508051b0251587ac43f816f6ee1e104057e1168032ba644e27bc1c7dc8__
+__00677291d73b71471afa49fe2d20b96f7227b05f863dafe802598964533e0dc3bc0cf7eb8153441db271a2288560378b209014350792f273bdc307f06ca34f0c6f__

--- a/resources/content/articles/en/2020-05-04_05-00-00_faucet-en.md
+++ b/resources/content/articles/en/2020-05-04_05-00-00_faucet-en.md
@@ -9,14 +9,17 @@ last_updated: 2020-06-03T10:00:00.000Z
 
 ### What is the Faucet?
 
-The faucet is a web-based service that provides free tokens to users of the testnet. The tokens enable users to experiment with Cardano features without spending ada cryptocurrency on the mainnet.
+The faucet is a web-based service that provides test ada (also known as 'tADA', 'fake ada' or 'fADA') to users of the testnet. While these tokens have no 'real world' value, they enable users to experiment with Cardano testnet features, without having to spend real ada on the mainnet.
                 
 #### To request tokens using the faucet:
 
 1. Enter the address of the account where you want to top up funds.
-1. Optionally enter your API key to bypass rate limiting.
+1. If you have been issued with an API key, please enter this to access any additional funds you may have been allocated
 1. Click on **Request**.
-1. Funds will be in the account you specified within a short interval.
-1. When you have finished using your test tokens, please return them to the faucet so that other members of the community can use them. Please return your test tokens to this address: __615609ae508051b0251587ac43f816f6ee1e104057e1168032ba644e27bc1c7dc8__
+1. Funds will be in the testnet account you specified within a few minutes
 
 <!-- include components/ShelleyHaskellFaucet -->
+
+_When you have finished using your test tokens, please return them to the faucet so that other members of the community can use them. Please return your test tokens to this address:_
+
+__615609ae508051b0251587ac43f816f6ee1e104057e1168032ba644e27bc1c7dc8__

--- a/resources/content/articles/en/2020-05-04_05-00-00_faucet-en.md
+++ b/resources/content/articles/en/2020-05-04_05-00-00_faucet-en.md
@@ -1,0 +1,22 @@
+---
+parent: 2020-05-04_05-00-00_tools
+title: Faucet
+description: Shelley tools
+order: 1
+last_updated: 2020-06-03T10:00:00.000Z
+---
+## Faucet
+
+### What is the Faucet?
+
+The faucet is a web-based service that provides free tokens to users of the testnet. The tokens enable users to experiment with Cardano features without spending ada cryptocurrency on the mainnet.
+                
+#### To request tokens using the faucet:
+
+1. Enter the address of the account where you want to top up funds.
+1. Optionally enter your API key to bypass rate limiting.
+1. Click on **Request**.
+1. Funds will be in the account you specified within a short interval.
+1. When you have finished using your test tokens, please return them to the faucet so that other members of the community can use them. Please return your test tokens to this address: __615609ae508051b0251587ac43f816f6ee1e104057e1168032ba644e27bc1c7dc8__
+
+<!-- include components/ShelleyHaskellFaucet -->

--- a/src/components/Faucet.js
+++ b/src/components/Faucet.js
@@ -183,10 +183,16 @@ const FaucetInner = ({ content, getEndpoint, hasApiKey, getTransactionURL }) => 
           <Markdown
             source={content.faucet_content.transaction_successful.replace(/{{\samount\s}}/g, getTransactionAmount()).replace(/{{\saddress\s}}/, values.address)}
           />
-          {result.txid &&
+          {result.txid && getTransactionURL &&
             <Fragment>
               <p>{content.faucet_content.verify_transaction_hash}</p>
               <p><strong><Link href={getTransactionURL({ txid: result.txid })}>{result.txid}</Link></strong></p>
+            </Fragment>
+          }
+          {result.txid && !getTransactionURL &&
+            <Fragment>
+              <p>{content.faucet_content.verify_transaction_hash}</p>
+              <p><strong>{result.txid}</strong></p>
             </Fragment>
           }
           <Box marginTop={2}>
@@ -204,7 +210,7 @@ FaucetInner.propTypes = {
   content: PropTypes.object.isRequired,
   getEndpoint: PropTypes.func.isRequired,
   hasApiKey: PropTypes.bool.isRequired,
-  getTransactionURL: PropTypes.func.isRequired
+  getTransactionURL: PropTypes.func
 }
 
 const Faucet = ({ getEndpoint, hasApiKey, getTransactionURL }) => (
@@ -223,7 +229,7 @@ const Faucet = ({ getEndpoint, hasApiKey, getTransactionURL }) => (
 Faucet.propTypes = {
   getEndpoint: PropTypes.func.isRequired,
   hasApiKey: PropTypes.bool.isRequired,
-  getTransactionURL: PropTypes.func.isRequired
+  getTransactionURL: PropTypes.func
 }
 
 export default Faucet

--- a/src/components/MarkdownComponents/ShelleyHaskellFaucet.js
+++ b/src/components/MarkdownComponents/ShelleyHaskellFaucet.js
@@ -3,8 +3,7 @@ import Faucet from '../Faucet'
 
 export default () => (
   <Faucet
-    getEndpoint={({ address, apiKey }) => `https://shelley-haskell-testnet.iohkdev.io/send-money/${address}?apiKey=${apiKey}`}
+    getEndpoint={({ address, apiKey }) => `https://faucet.ff.dev.cardano.org/send-money/${address}?apiKey=${apiKey}`}
     hasApiKey
-    getTransactionURL={({ txid }) => `https://shelleyexplorer.cardano.org/transaction/${txid}/`}
   />
 )


### PR DESCRIPTION
## What? (required)

* Added the faucet to Shelley for the Friends and Family (FF) testnet

## Why? (optional)

Why has this change occurred if applicable?

## How can this be tested? (optional)

* Can be tested locally, you will need an API key as well as an address to send the funds to.
* The faucet is located at `/en/shelley/tools/faucet/`
* The faucet can be tested on the staging URL once this PR has been merged. This is due to CORS restricting access to a list of domains.

## Screenshots (optional)

<img width="1173" alt="Screenshot 2020-06-08 at 09 53 34" src="https://user-images.githubusercontent.com/11139198/84011471-11e5f000-a96e-11ea-8a1a-f22bf19af1f3.png">
<img width="910" alt="Screenshot 2020-06-08 at 09 54 14" src="https://user-images.githubusercontent.com/11139198/84011464-0eeaff80-a96e-11ea-9f0d-86fd450c6944.png">

