### PR TITLE
Various changes on installing dependencies and build

### DIFF
--- a/resources/content/articles/en/2020-05-05_16-19-26_building-the-node-from-source-en.md
+++ b/resources/content/articles/en/2020-05-05_16-19-26_building-the-node-from-source-en.md
@@ -9,7 +9,7 @@ redirects:
   - from: /en/shelley-haskell/get-started/installing-and-running-the-cardano-node/building-the-node-from-source/
     type: 301
 ---
-## Building a node from source
+## Installing dependancies
 By building and running a node directly from the source code, you can ensure that you get all the latest code updates.
 
 The following instructions presume that you will be running your node on a Linux system and are using cabal. For more information, see the [supported platforms](shelley/about/supported-platforms/) page. You can run a node on any platform by [using a virtual machine](/shelley/get-started/installing-and-running-the-cardano-node/running-the-node-on-an-aws-instance/).
@@ -31,7 +31,6 @@ CentOS/RHEL based system
 sudo yum update -y
 sudo yum install git gcc gmp-devel -y
 sudo yum install zlib-devel systemd-devel ncurses-devel -y
-curl -sSL https://get.haskellstack.org/ | sh
 ```
 
 Debian/Ubuntu use the following instead:
@@ -39,12 +38,34 @@ Debian/Ubuntu use the following instead:
 ```shell
 sudo apt-get update -y
 sudo apt-get install build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libncursesw5 -y
-curl -sSL https://get.haskellstack.org/ | sh
 ```
 
 If you are using a different flavor of Linux, you will need to use the package manager suitable for your platform, and the names of the packages you need to install might differ.
 
-How to build and run the node from source:
+download, unpack, install and update Cabal:
+
+    wget https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz
+    tar -xf cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz
+    rm cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz cabal.sig
+    mkdir -p ~/.local/bin
+    mv cabal ~/.local/bin/
+
+download and install GHC:
+
+    wget https://downloads.haskell.org/~ghc/8.6.5/ghc-8.6.5-x86_64-deb9-linux.tar.xz
+    tar -xf ghc-8.6.5-x86_64-deb9-linux.tar.xz
+    rm ghc-8.6.5-x86_64-deb9-linux.tar.xz
+    cd ghc-8.6.5
+    ./configure
+    sudo make install
+
+Add ~/.cabal/bin/ and ~/.local/bin/ to the PATH
+
+Then run:
+
+    cabal update
+
+## How to build and run the node from source:
 
 1. In the terminal, run the following git command to clone the Cardano node repository and download the source code:
    ```shell
@@ -58,14 +79,14 @@ How to build and run the node from source:
    ```shell
    cd cardano-node
    ```
-1. You should check out the latest release, for example tag 1.11.0 using the following command:
+1. You should check out the latest release, for example tag 1.13.0 using the following command:
    ```shell
    git fetch --all --tags
-   git checkout tags/1.11.0
+   git checkout tags/1.13.0
    ```
 5. Build the source code using Cabal by running the following command:
    ```shell
-   build all
+   cabal install cardano-node cardano-cli
    ```
 Please note that building the node may take some time, possibly several hours.  
 6. Run the following command to initialize the node:

--- a/resources/content/articles/en/2020-05-05_16-19-26_building-the-node-from-source-en.md
+++ b/resources/content/articles/en/2020-05-05_16-19-26_building-the-node-from-source-en.md
@@ -26,6 +26,7 @@ To build and run a node from source, you need the following packages and tools:
 
 You can install these dependencies as follows:
 
+CentOS/RHEL based system
 ```shell
 sudo yum update -y
 sudo yum install git gcc gmp-devel -y
@@ -33,7 +34,15 @@ sudo yum install zlib-devel systemd-devel ncurses-devel -y
 curl -sSL https://get.haskellstack.org/ | sh
 ```
 
-If you are using a different flavor of Linux, you will need to use the package manager suitable for your platform, instead of yum, and the names of the packages you need to install might differ.
+Debian/Ubuntu use the following instead:
+
+```shell
+sudo apt-get update -y
+sudo apt-get install build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libncursesw5 -y
+curl -sSL https://get.haskellstack.org/ | sh
+```
+
+If you are using a different flavor of Linux, you will need to use the package manager suitable for your platform, and the names of the packages you need to install might differ.
 
 How to build and run the node from source:
 


### PR DESCRIPTION
## What? (required)

* Various changes required for installing dependencies in different Os
* Changed version to checkout from 1.11 to 1.13 (major changes in commands between those versions)
* Changing the build method from build all to cabal install.

Why has this change occurred if applicable?

* Latest version of the node is 1.13.0 
* We have been using cabal to build the node, not stack so removed the need of stack 
* We ned GHC 

## How can this be tested? (optional)

Describe how this change can be tested

## Screenshots (optional)

Upload some screenshots of the changes
