### PR TITLE
Corrected install-nix command

### DIFF
--- a/resources/content/articles/en/2020-05-05_16-18-17_building-the-node-using-nix-en.md
+++ b/resources/content/articles/en/2020-05-05_16-18-17_building-the-node-using-nix-en.md
@@ -31,7 +31,7 @@ chmod +x ./install-nix.sh
 3. Run:
 
 ```shell
-./install-nix.sh --daemon --nix-extra-conf-files nix.conf
+./install-nix.sh --daemon --nix-extra-conf-file nix.conf
 ```
 
 4. Follow the instructions presented as part of the Nix installation process.


### PR DESCRIPTION
The proper flag to install nix with extract configuration files is --nix-extra-conf-file (not pluralised).

## What? (required)

Changed ```--nix-extra-conf-files``` to ```--nix-extra-conf-file```