### PR TITLE
Update resources

### DIFF
--- a/resources/content/articles/en/2020-05-04_05-00-00_community-en.md
+++ b/resources/content/articles/en/2020-05-04_05-00-00_community-en.md
@@ -12,8 +12,7 @@ redirects:
 
 Community collaboration is central to the success of the Cardano testnet. This page provides some community-generated content that we have gathered and deemed complementary to the content we are producing. As these materials were not produced by IOHK, we cannot verify that their content is fully accurate or completely up-to-date.
 
-* [creating your own Cardano Haskell node](https://guides.poapool.com/ff-haskell-testnet/create-your-own-cardano-haskell-node-new)
-* [Guild operator guide](https://cardano-community.github.io/guild-operators/Home.html)
+* [Guild operator guide](https://cardano-community.github.io/guild-operators)
 * [big pey's stake pool video tutorials](https://www.youtube.com/playlist?list=PLyThQPJpttTJ4r9wUdlWi1DMty4nAT85d)
 * [creating a private testnet using Docker](https://github.com/ItFlyingStart/shelley-private-testnet)
 * [useful setup scripts](https://github.com/gitmachtl/scripts/tree/master/cardano)


### PR DESCRIPTION
## What/Why? (required)
- POA Guides were retired (and lead to 404)
- Guild Operators Repo URL was incorrect