### PR TITLE
Update 2020-05-05_16-18-17_building-the-node-using-nix-en.md

### DIFF
--- a/resources/content/articles/en/2020-05-05_16-18-17_building-the-node-using-nix-en.md
+++ b/resources/content/articles/en/2020-05-05_16-18-17_building-the-node-using-nix-en.md
@@ -31,7 +31,7 @@ chmod +x ./install-nix.sh
 3. Run:
 
 ```shell
-./install-nix.sh --daemon --nix-extra-conf-files nix.conf
+./install-nix.sh --daemon --nix-extra-conf-file nix.conf
 ```
 
 4. Follow the instructions presented as part of the Nix installation process.


### PR DESCRIPTION
removed redundant 's' from command. Fixes https://github.com/cardano-foundation/testnets-cardano-org/issues/414

## What? (required)

What has changed/been added?

## Why? (optional)

Why has this change occurred if applicable?

## How can this be tested? (optional)

Describe how this change can be tested

## Screenshots (optional)

Upload some screenshots of the changes
