### PR TITLE
update theme.js to stop auto capitalisation of titles

### DIFF
--- a/src/themes.js
+++ b/src/themes.js
@@ -12,28 +12,28 @@ const commonTheme = {
       fontWeight: 700,
       lineHeight: 1.1,
       letterSpacing: 0,
-      textTransform: 'capitalize'
+      textTransform: 'none'
     },
     h2: {
       fontSize: 1.8,
       fontWeight: 700,
       letterSpacing: 0.05,
       lineHeight: 1.2,
-      textTransform: 'capitalize'
+      textTransform: 'none'
     },
     h3: {
       fontSize: 1.44,
       fontWeight: 700,
       lineHeight: 1.2,
       letterSpacing: 0.05,
-      textTransform: 'capitalize'
+      textTransform: 'none'
     },
     h4: {
       fontSize: 1.1,
       fontWeight: 700,
       letterSpacing: 0.05,
       lineHeight: 1.2,
-      textTransform: 'capitalize'
+      textTransform: 'none'
     },
     h5: {
       fontSize: 0.7,


### PR DESCRIPTION
## What? (required)
Removed `text-transform: capitalize`, replaced with `text-transform: none`.

What has changed/been added?

## Why? (optional)

Why has this change occurred if applicable?

## How can this be tested? (optional)

Describe how this change can be tested

## Screenshots (optional)

Upload some screenshots of the changes
