### PR TITLE
Performance optimizations

### DIFF
--- a/scripts/lint-since-last-commit.sh
+++ b/scripts/lint-since-last-commit.sh
@@ -1,17 +1,9 @@
 #!/bin/bash
 set -e
 
-CHANGED_FILES=`git diff --name-only --cached --relative | grep '\.jsx\?$' | xargs`
-CHANGED_FILES_ARRAY=(${CHANGED_FILES// / })
-RESOLVED_CHANGED_FILES=""
-for i in "${!CHANGED_FILES_ARRAY[@]}"
-do
-  if [ -f "${CHANGED_FILES_ARRAY[i]}" ]; then
-    RESOLVED_CHANGED_FILES+=" ${CHANGED_FILES_ARRAY[i]}"
-  fi
-done
+declare CHANGED_FILES=$(git diff --name-only --cached --relative '*.jsx' '*.js' | xargs -r ls -1 2>/dev/null)
 
-if [ "$RESOLVED_CHANGED_FILES" != "" ]; then
-  npm run lint:changed -- $RESOLVED_CHANGED_FILES
-  if [ $? -ne 0 ]; then exit 1; fi
+if [ -n "$CHANGED_FILES" ]; then
+  npm run lint:changed -- $CHANGED_FILES
+  [ $? -ne 0 ] && exit 1
 fi


### PR DESCRIPTION
grep command not needed same can be done in git diff

no need to loop for file existance. Same can be achieved via xargs

redundant calls to npm run lint fixed

## What? (required)

`CHANGED_FILES=`git` diff --name-only --cached --relative | grep '\.jsx\?$' | xargs`
to
`CHANGED_FILES=$(git` diff --name-only --cached --relative '*.jsx' '*.js' | xargs -r ls -1 2>/dev/null)

`CHANGED_FILES_ARRAY=(${CHANGED_FILES// / })
RESOLVED_CHANGED_FILES=""
for i in "${!CHANGED_FILES_ARRAY[@]}"
do
  if [ -f "${CHANGED_FILES_ARRAY[i]}" ]; then
    RESOLVED_CHANGED_FILES+=" ${CHANGED_FILES_ARRAY[i]}"
  fi
done
if [ "$RESOLVED_CHANGED_FILES" != "" ]; then
  npm run lint:changed -- $RESOLVED_CHANGED_FILES
  if [ $? -ne 0 ]; then exit 1; fi
fi
`
to
`if [ -n "$CHANGED_FILES" ]; then
  npm run lint:changed -- $CHANGED_FILES
  [ $? -ne 0 ] && exit 1
fi
`

## Why? (optional)

Why has this change occurred if applicable?

## How can this be tested? (optional)

Describe how this change can be tested

## Screenshots (optional)

Upload some screenshots of the changes
